### PR TITLE
BsonDecodeError extends Exception and populates error message

### DIFF
--- a/core/src/main/scala/mongo4cats/bson/BsonDecoder.scala
+++ b/core/src/main/scala/mongo4cats/bson/BsonDecoder.scala
@@ -18,7 +18,7 @@ package mongo4cats.bson
 
 import org.bson._
 
-final case class BsonDecodeError(msg: String) extends Throwable
+final case class BsonDecodeError(msg: String) extends Exception(msg)
 
 trait BsonDecoder[A] extends Serializable { self =>
   def apply(b: BsonValue): Either[BsonDecodeError, A]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1"
+version in ThisBuild := "0.5.2"


### PR DESCRIPTION
Makes for a better behaved `Throwable` and a useful `toString`.