### PR TITLE
Add replaceRoot aggregation stage

### DIFF
--- a/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
+++ b/core/src/main/scala/mongo4cats/collection/operations/Aggregate.scala
@@ -85,6 +85,9 @@ final case class Aggregate private (private val aggs: List[Bson]) {
   def replaceWith[T: BsonEncoder](value: T): Aggregate =
     add(Aggregates.replaceWith(value.asBson))
 
+  def replaceRoot[T: BsonEncoder](value: T): Aggregate =
+    add(Aggregates.replaceRoot(value.asBson))
+
   def lookup(from: String, pipeline: Aggregate, as: String): Aggregate =
     add(Aggregates.lookup(from, pipeline.toBsons.asJava, as))
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2"
+version in ThisBuild := "0.6.0"


### PR DESCRIPTION
Adds the `$replaceRoot` aggregation stage for compatibility on mongo versions that predate `$replaceWith`.